### PR TITLE
problem with generating sitemap when site has no article (fixed)

### DIFF
--- a/app/Http/Controllers/SiteMapController.php
+++ b/app/Http/Controllers/SiteMapController.php
@@ -16,7 +16,7 @@ class SiteMapController extends Controller
         }
 
         $paginatedArticles = Article::getPaginated();
-        $latestArticleAt = $paginatedArticles->first()->created_at;
+        $latestArticleAt = $paginatedArticles->first()->created_at ?? Carbon::now()->toDateString();
 
         $sitemap->addSitemap('articles');
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request: 
when a site has no article generating sitemap will get an error because there is no checking after getting articles from the database that are there any record or not .
@alimranahmed
